### PR TITLE
Fix error in LR row linking

### DIFF
--- a/dlx/__init__.py
+++ b/dlx/__init__.py
@@ -131,7 +131,7 @@ class DLX:
             self.L[self.R[self.nodect]] = self.nodect
 
             self.N.append(rowName)
-            self.prev = self.nodect
+            prev = self.nodect
             self.nodect += 1
         return first
 


### PR DESCRIPTION
Incorrect usage of prev made the rows linked lists be incorrectly ordered, while maintaining functionality.

More specifically, rather than the nodes of a particular row be ordered
1 <-> 2 <-> ... <-> N <-> back to 1

They are ordered 
1 <-> N <-> ... <-> 2 <-> back to 1

due to this mistake.
This does not affect the execution of the algorithm, as any time we use rows' L-R pointers, we traverse the whole list, and the list still is correctly linking all the nodes. 